### PR TITLE
fix basic type conversions from pointer to non-pointer

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -342,8 +342,6 @@ func newAssignStmtStructsAndPointers(
 	case !leftPtr && rightPtr:
 		// Pointer to Value
 		//
-		// <left> = *<right>
-
 		// if <right> != nil {
 		//   <left> = *<right>
 		// } else {
@@ -351,7 +349,6 @@ func newAssignStmtStructsAndPointers(
 		// }
 
 		leftPtrType, leftPtr := leftType.(*ast.StarExpr)
-		// _, rightPtr := rightType.(*ast.StarExpr)
 
 		leftRealType := leftType
 		if leftPtr {
@@ -368,8 +365,6 @@ func newAssignStmtStructsAndPointers(
 				astAssign(left, &ast.Ident{Name: varNamePlaceholder}),
 			}},
 		}
-
-		// return astAssign(left, &ast.StarExpr{X: right})
 	case leftPtr && !rightPtr:
 		// Value to Pointer
 		//

--- a/ast.go
+++ b/ast.go
@@ -345,9 +345,9 @@ func newAssignStmtStructsAndPointers(
 		// if <right> != nil {
 		//   <left> = *<right>
 		// } else {
-		//   <left> = nil
+		//   var z <left_type>
+		//   <left> = z
 		// }
-
 		leftPtrType, leftPtr := leftType.(*ast.StarExpr)
 
 		leftRealType := leftType

--- a/internal/e2e/core/cluster_node.go
+++ b/internal/e2e/core/cluster_node.go
@@ -12,7 +12,7 @@ type ClusterNode struct {
 	Label Label
 	// Labels []Label
 	// WorkPointer []*Workload
-	Flag *bool
+	Flag   *bool
 	Number uint32
 
 	O *Other

--- a/internal/e2e/core/cluster_node.go
+++ b/internal/e2e/core/cluster_node.go
@@ -12,6 +12,8 @@ type ClusterNode struct {
 	Label Label
 	// Labels []Label
 	// WorkPointer []*Workload
+	Flag *bool
+	Number uint32
 
 	O *Other
 	I inner.Inner
@@ -55,6 +57,7 @@ type ClusterNode struct {
 }
 
 type StringSlice []string
+
 type WorkloadSlice []*Workload
 
 type Workload struct {

--- a/internal/e2e/sourcepkg/node.go
+++ b/internal/e2e/sourcepkg/node.go
@@ -19,6 +19,8 @@ type Node struct {
 	ID     string
 	Weight int64
 	Label  string
+	Flag   bool
+	Number *uint32
 	// Labels []string
 	Meta map[string]interface{}
 	Work []Workload
@@ -66,6 +68,7 @@ type Node struct {
 }
 
 type StringSlice []string
+
 type WorkloadSlice []Workload
 
 // mog annotation:

--- a/testdata/TestE2E-expected-node_gen.go
+++ b/testdata/TestE2E-expected-node_gen.go
@@ -10,6 +10,13 @@ func NodeToCore(s *Node, t *core.ClusterNode) {
 	}
 	t.ID = s.ID
 	t.Label = core.Label(s.Label)
+	t.Flag = &s.Flag
+	if s.Number != nil {
+		t.Number = *s.Number
+	} else {
+		var x uint32
+		t.Number = x
+	}
 	t.O = s.O
 	t.I = s.I
 	WorkloadToCore(&s.F1, &t.F1)
@@ -31,7 +38,12 @@ func NodeToCore(s *Node, t *core.ClusterNode) {
 	{
 		t.S3 = make([]string, len(s.S3))
 		for i := range s.S3 {
-			t.S3[i] = *s.S3[i]
+			if s.S3[i] != nil {
+				t.S3[i] = *s.S3[i]
+			} else {
+				var x string
+				t.S3[i] = x
+			}
 		}
 	}
 	{
@@ -112,7 +124,12 @@ func NodeToCore(s *Node, t *core.ClusterNode) {
 		t.M3 = make(map[string]string, len(s.M3))
 		for k, v := range s.M3 {
 			var y string
-			y = *v
+			if v != nil {
+				y = *v
+			} else {
+				var x string
+				y = x
+			}
 			t.M3[k] = y
 		}
 	}
@@ -173,6 +190,13 @@ func NodeFromCore(t *core.ClusterNode, s *Node) {
 	}
 	s.ID = t.ID
 	s.Label = string(t.Label)
+	if t.Flag != nil {
+		s.Flag = *t.Flag
+	} else {
+		var x bool
+		s.Flag = x
+	}
+	s.Number = &t.Number
 	s.O = t.O
 	s.I = t.I
 	WorkloadFromCore(&t.F1, &s.F1)
@@ -200,7 +224,12 @@ func NodeFromCore(t *core.ClusterNode, s *Node) {
 	{
 		s.S4 = make([]string, len(t.S4))
 		for i := range t.S4 {
-			s.S4[i] = *t.S4[i]
+			if t.S4[i] != nil {
+				s.S4[i] = *t.S4[i]
+			} else {
+				var x string
+				s.S4[i] = x
+			}
 		}
 	}
 	{
@@ -277,7 +306,12 @@ func NodeFromCore(t *core.ClusterNode, s *Node) {
 		s.M4 = make(map[string]string, len(t.M4))
 		for k, v := range t.M4 {
 			var y string
-			y = *v
+			if v != nil {
+				y = *v
+			} else {
+				var x string
+				y = x
+			}
 			s.M4[k] = y
 		}
 	}


### PR DESCRIPTION
Conversions from things like `bool <-> *bool` or `uint32 <-> *uint32` would panic if the RHS was `nil` as it would just generate:
```
x = *y
```

This fixes it so that it does the following in that scenario:
```
if y != nil {
  x = *y
} else {
  var z <original_type>
  x = z
}
```